### PR TITLE
Add Docker-based build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+####################
+# Setup base image #
+####################
+
+# Make sure a test build succeeds before committing a bump to this
+FROM ubuntu:jammy-20240227 AS base
+
+RUN apt-get update -y \
+    && apt-get install -y make libgmp3-dev libmpc-dev libmpfr-dev texinfo \
+       nasm xz-utils g++ curl git
+
+ENV TARGET=i386-elf
+ENV PREFIX="/opt/cross"
+ENV PATH="$PREFIX/bin:$PATH"
+
+## binutils
+FROM base AS binutils
+
+WORKDIR /build
+
+ARG BINUTILS_VERSION=2.42
+RUN curl "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz" | tar -xJC / \
+    &&  /binutils-${BINUTILS_VERSION}/configure --target="$TARGET" --prefix="$PREFIX" \
+        --with-sysroot --disable-nls --disable-werror \
+    && make \
+    && make install
+
+## gcc
+FROM base AS gcc
+
+WORKDIR /build
+COPY --from=binutils /opt/cross /opt/cross
+
+ARG GCC_VERSION=13.2.0
+# TODO: Add argument for setting `-j 8` parallelism?
+# Note: If debugging issues with `make all-target-libgcc`, split this into multiple RUN commands
+#       to ensure that Docker build cache can prevent rerunning `make all-gcc`
+RUN curl "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz" | tar -xJC / \
+    && /gcc-${GCC_VERSION}/configure --target="$TARGET" --prefix="$PREFIX" --disable-nls \
+       --enable-languages=c,c++ --without-headers \
+    && make -j 8 all-gcc \
+    && make all-target-libgcc \
+    && make install-gcc \
+    && make install-target-libgcc
+
+###############
+# Build image #
+###############
+
+FROM base AS builder
+
+ARG GNU_EFI_VERSION=3.0.18
+RUN git clone https://git.code.sf.net/p/gnu-efi/code gnu-efi \
+    && cd gnu-efi \
+    && git checkout ${GNU_EFI_VERSION} \
+    && make
+
+COPY --from=gcc /opt/cross /opt/cross
+WORKDIR /novos
+COPY . .
+
+RUN make build TOOLPATH="${PREFIX}/bin/"
+
+####################
+# Export artifacts #
+####################
+
+FROM scratch AS export
+COPY --from=builder /novos/bin /

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ the other thing i do want to do is try and make *some* note about anything parti
 
 following the principle above, i'm trying to keep the build environment simple. everything that builds the project is in the Makefile, and its all just there so you can read it and actually understand the build process.
 
-the `build_toolchain.sh` script should download and install all the necessarry tools for building the project, but if it doesn't work on your platform you might be able to figure out what you need manually (again, i need to get on this).
+the `build_toolchain.sh` script should download and install all the necessary tools for building the project on Ubuntu, but if it doesn't work on your platform you might be able to figure out what you need manually (again, i need to get on this).
 
 alternatively you can download prebuilt binaries from the releases tab and run them under qemu-system-x86_64/qemu-system-i386. again, the binary should stand entirely on its own.
+
+### build with Docker
+
+alternatively-alternatively you can use Docker to build the image.
+
+prerequisites:
+- Docker
+- make*
+- qemu (system-x86_64/system-i386) to run the resulting image
+
+just run `make docker` and it should output files into `./bin/`. the first run will take a few minutes as it build the required dependencies, but subsequent runs only need to build the actual image thanks to Docker layer caching.
+as a \*very* rough guide, `docker system df` reports using ~6.5GB after a build (having pruned beforehand), but that will *not* grow significantly with subsequent reruns.
+
+additionally, the Dockerfile shows the exact steps and dependencies required on Ubuntu, so can serve as a rough guide on what tools/steps are required in other environments.
+
+\*technically make is optional - have a look at the Makefile's `docker` recipe to see what it does (it's just being used as a command runner).


### PR DESCRIPTION
Significantly simplifies the build process and allows other distributions/OSes to build it in a reproducible way.

The Dockerfile has been designed to take maximum advantage of the build system's layer caching, which prevents rebuilds of dependencies when not required.