### PR TITLE
Use gzip'ed instead of xz'ed archives [Docker]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:jammy-20240227 AS base
 
 RUN apt-get update -y \
     && apt-get install -y make libgmp3-dev libmpc-dev libmpfr-dev texinfo \
-       nasm xz-utils g++ curl git
+       nasm gzip g++ curl git
 
 ENV TARGET=i386-elf
 ENV PREFIX="/opt/cross"
@@ -19,7 +19,7 @@ FROM base AS binutils
 WORKDIR /build
 
 ARG BINUTILS_VERSION=2.42
-RUN curl "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz" | tar -xJC / \
+RUN curl "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" | tar -xzC / \
     &&  /binutils-${BINUTILS_VERSION}/configure --target="$TARGET" --prefix="$PREFIX" \
         --with-sysroot --disable-nls --disable-werror \
     && make \
@@ -35,7 +35,7 @@ ARG GCC_VERSION=13.2.0
 # TODO: Add argument for setting `-j 8` parallelism?
 # Note: If debugging issues with `make all-target-libgcc`, split this into multiple RUN commands
 #       to ensure that Docker build cache can prevent rerunning `make all-gcc`
-RUN curl "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz" | tar -xJC / \
+RUN curl "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.gz" | tar -xzC / \
     && /gcc-${GCC_VERSION}/configure --target="$TARGET" --prefix="$PREFIX" --disable-nls \
        --enable-languages=c,c++ --without-headers \
     && make -j 8 all-gcc \

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ prerequisites:
 - make*
 - qemu (system-x86_64/system-i386) to run the resulting image
 
-just run `make docker` and it should output files into `./bin/`. the first run will take a few minutes as it build the required dependencies, but subsequent runs only need to build the actual image thanks to Docker layer caching.
+just run `make docker` and it should output files into `./bin/`. the first run will take a few minutes as it builds the required dependencies, but subsequent runs only need to build the actual image thanks to Docker layer caching.
 as a \*very* rough guide, `docker system df` reports using ~6.5GB after a build (having pruned beforehand), but that will *not* grow significantly with subsequent reruns.
 
 additionally, the Dockerfile shows the exact steps and dependencies required on Ubuntu, so can serve as a rough guide on what tools/steps are required in other environments.


### PR DESCRIPTION
In light of the recent backdoor in xz, use the .tar.gz archives instead of .tar.xz for binutils and gcc.
Realistically, the backdoor would not be an issue as apt would not install an infected version, but it's better to be safe than sorry.